### PR TITLE
Correction of data conflict (race) error.

### DIFF
--- a/html/html.go
+++ b/html/html.go
@@ -194,12 +194,16 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 		if lay == nil {
 			return fmt.Errorf("render: layout %s does not exist", layout[0])
 		}
-		lay.Funcs(map[string]interface{}{
+		layCopy, err := lay.Clone()
+		if err != nil {
+			return err
+		}
+		layCopy.Funcs(map[string]interface{}{
 			e.layout: func() error {
 				return tmpl.Execute(out, binding)
 			},
 		})
-		return lay.Execute(out, binding)
+		return layCopy.Execute(out, binding)
 	}
 	return tmpl.Execute(out, binding)
 }


### PR DESCRIPTION
```
lay.Funcs(map[string]interface{}{ // This will change the global template object
	e.layout: func() error {
		return tmpl.Execute(out, binding)
	},
})
return lay.Execute(out, binding) // Under high load, artifacts can occur because data integrity is not controlled by the mutex.
```

A situation occurs when a part of a template is rendered in another request

To avoid this situation, a copy of this template should be obtained before changing the global template:
```
layCopy, err := lay.Clone()
if err != nil {
	return err
}
layCopy.Funcs(map[string]interface{}{ // Changes are not made in the global template, but changes in the local copy of it
	e.layout: func() error {
		return tmpl.Execute(out, binding)
	},
})
return layCopy.Execute(out, binding) // No data race.
```