### PR TITLE
change the jade/pug link to prevent an error with the link

### DIFF
--- a/pug/README.md
+++ b/pug/README.md
@@ -1,6 +1,6 @@
 # Pug
 
-Pug is a template engine create by [joker](github.com/Joker/jade), to see the original syntax documentation please [click here](https://pugjs.org/language/tags.html)
+Pug is a template engine create by [joker](https://github.com/Joker/jade), to see the original syntax documentation please [click here](https://pugjs.org/language/tags.html)
 
 ### Basic Example
 


### PR DESCRIPTION
The created link is missing the protocol format right now, which causes GitHub to create a relative link that ends in a 404 error. This PR integrates the protocol to fix it and to allow the linking 