### PR TITLE
v1.6.5 breaks filesystem embedding support like packr, gobindata etc.

### DIFF
--- a/django/django.go
+++ b/django/django.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/flosch/pongo2"
+	"github.com/flosch/pongo2/v4"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/template/utils"
 )
@@ -118,15 +118,18 @@ func (e *Engine) Load() error {
 
 	e.Templates = make(map[string]*pongo2.Template)
 
-	// New pongo2 defaultset
 	baseDir := e.directory
-	// TODO: work around until pongo2 support native http.FileSystem in stable release
-	if e.fileSystem != nil {
-		baseDir = fmt.Sprint(e.fileSystem)
-	}
-	pongoloader := pongo2.MustNewLocalFileSystemLoader(baseDir)
-	pongoset := pongo2.NewSet("default", pongoloader)
 
+	var pongoloader pongo2.TemplateLoader
+	if e.fileSystem != nil {
+		// ensures creation of httpFileSystemLoader only when filesystem is defined
+		pongoloader = pongo2.MustNewHttpFileSystemLoader(e.fileSystem, baseDir)
+	} else {
+		pongoloader = pongo2.MustNewLocalFileSystemLoader(baseDir)
+	}
+
+	// New pongo2 defaultset
+	pongoset := pongo2.NewSet("default", pongoloader)
 	// Set template settings
 	pongoset.Globals.Update(e.funcmap)
 	pongo2.SetAutoescape(false)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/template
 
-go 1.14
+go 1.15
 
 require (
 	github.com/CloudyKit/jet/v3 v3.0.1
@@ -9,7 +9,7 @@ require (
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/cbroglie/mustache v1.2.0
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
-	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3
+	github.com/flosch/pongo2/v4 v4.0.1
 	github.com/gofiber/fiber/v2 v2.2.2
 	github.com/mattn/go-slim v0.0.0-20200618151855-bde33eecb5ee
 	github.com/valyala/bytebufferpool v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 h1:fmFk0Wt3bBxxwZnu48jqMdaOR/IZ4vdtJFuaFV8MpIE=
-github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3/go.mod h1:bJWSKrZyQvfTnb2OudyUjurSG4/edverV7n82+K3JiM=
+github.com/flosch/pongo2/v4 v4.0.1 h1:l/49mdkeTYSHzH9N4Iwjs0yMqELMKCsYv5PzTm37Gio=
+github.com/flosch/pongo2/v4 v4.0.1/go.mod h1:B5ObFANs/36VwxxlgKpdchIJHMvHB562PW+BWPhwZD8=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
- pongo2/v4 has been released with HttpFileSystemLoader support, thus now we support both the TemplateLoader implementations:
  - HttpFileSystemLoader
  - LocalFileSystemLoader
- Upgrades go to 1.5

Fixes #71 
Signed-off-by: Ankur Srivastava