### PR TITLE
🐛 Fix: Template engine can only load template files ending in .html #124

### DIFF
--- a/ace/ace.go
+++ b/ace/ace.go
@@ -138,10 +138,8 @@ func (e *Engine) Load() error {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path

--- a/amber/amber.go
+++ b/amber/amber.go
@@ -141,10 +141,8 @@ func (e *Engine) Load() error {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path

--- a/django/django.go
+++ b/django/django.go
@@ -144,10 +144,8 @@ func (e *Engine) Load() error {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path

--- a/handlebars/handlebars.go
+++ b/handlebars/handlebars.go
@@ -120,10 +120,8 @@ func (e *Engine) Load() (err error) {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path

--- a/html/html.go
+++ b/html/html.go
@@ -139,10 +139,8 @@ func (e *Engine) Load() error {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path

--- a/jet/jet.go
+++ b/jet/jet.go
@@ -77,8 +77,6 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 	return engine
 }
 
-
-
 // Layout defines the variable name that will incapsulate the template
 func (e *Engine) Layout(key string) *Engine {
 	e.layout = key
@@ -121,7 +119,6 @@ func (e *Engine) Parse() error {
 	fmt.Println("Parse() is deprecated, please use Load() instead.")
 	return e.Load()
 }
-
 
 // Parse parses the templates to the engine.
 func (e *Engine) Load() (err error) {
@@ -170,10 +167,8 @@ func (e *Engine) Load() (err error) {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// ./views/html/index.tmpl -> index.tmpl
@@ -194,7 +189,7 @@ func (e *Engine) Load() (err error) {
 		if e.debug {
 			fmt.Printf("views: parsed template: %s\n", name)
 		}
-		
+
 		return err
 	}
 

--- a/mustache/mustache.go
+++ b/mustache/mustache.go
@@ -40,11 +40,11 @@ type Engine struct {
 
 type fileSystemPartialProvider struct {
 	fileSystem http.FileSystem
-	extension string
+	extension  string
 }
 
-func (p fileSystemPartialProvider) Get(path string)(string,error) {
-	buf, _ := utils.ReadFile(path + p.extension, p.fileSystem)
+func (p fileSystemPartialProvider) Get(path string) (string, error) {
+	buf, _ := utils.ReadFile(path+p.extension, p.fileSystem)
 	return string(buf), nil
 }
 
@@ -70,10 +70,10 @@ func NewFileSystemPartials(fs http.FileSystem, extension string, partialsFS http
 		fileSystem: fs,
 		partialsProvider: &fileSystemPartialProvider{
 			fileSystem: partialsFS,
-			extension: extension,
+			extension:  extension,
 		},
-		extension:  extension,
-		layout:     "embed",
+		extension: extension,
+		layout:    "embed",
 	}
 	return engine
 }
@@ -130,10 +130,8 @@ func (e *Engine) Load() error {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path
@@ -159,7 +157,7 @@ func (e *Engine) Load() error {
 		var tmpl *mustache.Template
 		if e.partialsProvider != nil {
 			tmpl, err = mustache.ParseStringPartials(string(buf), e.partialsProvider)
-		} else{
+		} else {
 			tmpl, err = mustache.ParseString(string(buf))
 		}
 		if err != nil {

--- a/slim/slim.go
+++ b/slim/slim.go
@@ -129,10 +129,8 @@ func (e *Engine) Load() error {
 		if info == nil || info.IsDir() {
 			return nil
 		}
-		// Get file extension of file
-		ext := filepath.Ext(path)
 		// Skip file if it does not equal the given template extension
-		if ext != e.extension {
+		if len(e.extension) >= len(path) || path[len(path)-len(e.extension):] != e.extension {
 			return nil
 		}
 		// Get the relative file path


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7063188/122278875-b25ae280-cee7-11eb-8d1a-27860f37ac82.png)
fixes the bug that templates with double extensions are not skipped 