### PR TITLE
New function `AddFuncMap` for html engine.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This package provides universal methods to use multiple template engines with th
 - [pug](https://github.com/gofiber/template/tree/master/pug)
 
 ### Installation
-> Go version `1.16` or higher is required.
+> Go version `1.13` or higher is required.
 
 ```
 go get -u github.com/gofiber/fiber/v2

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This package provides universal methods to use multiple template engines with th
 - [pug](https://github.com/gofiber/template/tree/master/pug)
 
 ### Installation
-> Go version `1.13` or higher is required.
+> Go version `1.16` or higher is required.
 
 ```
 go get -u github.com/gofiber/fiber/v2

--- a/html/html.go
+++ b/html/html.go
@@ -96,6 +96,17 @@ func (e *Engine) AddFunc(name string, fn interface{}) *Engine {
 	return e
 }
 
+// AddFuncMap adds the functions from a map to the template's function map.
+// It is legal to overwrite elements of the default actions
+func (e *Engine) AddFuncMap(m map[string]interface{}) *Engine {
+	e.mutex.Lock()
+	for name, fn := range m {
+		e.funcmap[name] = fn
+	}
+	e.mutex.Unlock()
+	return e
+}
+
 // Reload if set to true the templates are reloading on each render,
 // use it when you're in development and you don't want to restart
 // the application when you edit a template file.

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -82,11 +82,11 @@ func Test_AddFunc(t *testing.T) {
 
 func Test_AddFuncMap(t *testing.T) {
 	// Create a temporary directory
-	dir, _ := os.MkdirTemp(".", "")
+	dir, _ := ioutil.TempDir(".", "")
 	defer os.RemoveAll(dir)
 
 	// Create a temporary template file.
-	_ = os.WriteFile(dir+"/func_map.html", []byte(`<h2>{{lower .Var1}}</h2><p>{{upper .Var2}}</p>`), 0700)
+	_ = ioutil.WriteFile(dir+"/func_map.html", []byte(`<h2>{{lower .Var1}}</h2><p>{{upper .Var2}}</p>`), 0700)
 
 	engine := New(dir, ".html")
 


### PR DESCRIPTION
- New function `AddFuncMap` for html engine, useful for adding multiple functions from third-party library like [`sprig`](http://masterminds.github.io/sprig/). Let me know if you prefer name `AddFuncs()`.
- Disable Go 1.14 and 1.15 in GitHub Actions. According to `go.mod`, Go 1.16 is required.