### PR TITLE
Add ability to forward base path to django template engine

### DIFF
--- a/django/django.go
+++ b/django/django.go
@@ -33,6 +33,8 @@ type Engine struct {
 	reload bool
 	// debug prints the parsed templates
 	debug bool
+	// forward the base path to the template engine
+	forwardPath bool
 	// lock for funcmap and templates
 	mutex sync.RWMutex
 	// template funcmap
@@ -64,6 +66,15 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 		layout:     "embed",
 		funcmap:    make(map[string]interface{}),
 	}
+	return engine
+}
+
+// NewPathForwardingFileSystem Passes "directory" to the template engine where alternative functions.
+// 							   This fixes errors during resolution of templates when "{% extends 'parent.html' %}" is used.
+func NewPathForwardingFileSystem(fs http.FileSystem, directory string, extension string) *Engine {
+	engine := NewFileSystem(fs, extension)
+	engine.forwardPath = true
+	engine.directory = directory
 	return engine
 }
 
@@ -123,7 +134,11 @@ func (e *Engine) Load() error {
 	var pongoloader pongo2.TemplateLoader
 	if e.fileSystem != nil {
 		// ensures creation of httpFileSystemLoader only when filesystem is defined
-		pongoloader = pongo2.MustNewHttpFileSystemLoader(e.fileSystem, "")
+		if e.forwardPath {
+			pongoloader = pongo2.MustNewHttpFileSystemLoader(e.fileSystem, baseDir)
+		} else {
+			pongoloader = pongo2.MustNewHttpFileSystemLoader(e.fileSystem, "")
+		}
 	} else {
 		pongoloader = pongo2.MustNewLocalFileSystemLoader(baseDir)
 	}

--- a/django/django.go
+++ b/django/django.go
@@ -69,7 +69,7 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 	return engine
 }
 
-// NewPathForwardingFileSystem Passes "directory" to the template engine where alternative functions.
+// NewPathForwardingFileSystem Passes "directory" to the template engine where alternative functions don't.
 // 							   This fixes errors during resolution of templates when "{% extends 'parent.html' %}" is used.
 func NewPathForwardingFileSystem(fs http.FileSystem, directory string, extension string) *Engine {
 	engine := NewFileSystem(fs, extension)

--- a/django/django_1.16_test.go
+++ b/django/django_1.16_test.go
@@ -1,0 +1,35 @@
+//go:build go1.16
+// +build go1.16
+
+package django
+
+import (
+	"bytes"
+	"embed"
+	"net/http"
+	"testing"
+)
+
+//go:embed views
+var viewsAsssets embed.FS
+
+func Test_PathForwardingFileSystem(t *testing.T) {
+	engine := NewPathForwardingFileSystem(http.FS(viewsAsssets), "/views", ".django")
+	engine.Debug(true)
+	if err := engine.Load(); err != nil {
+		t.Fatalf("load: %v\n", err)
+	}
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "descendant", map[string]interface{}{
+		"greeting": "World",
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	expect := `<h1>Hello World! from ancestor</h1>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -2,6 +2,7 @@ package django
 
 import (
 	"bytes"
+	"embed"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -102,6 +103,30 @@ func Test_FileSystem(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	if expect != result {
+		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+}
+
+//go:embed views
+var viewsAsssets embed.FS
+
+func Test_PathForwardingFileSystem(t *testing.T) {
+	engine := NewPathForwardingFileSystem(http.FS(viewsAsssets), "/views", ".django")
+	engine.Debug(true)
+	if err := engine.Load(); err != nil {
+		t.Fatalf("load: %v\n", err)
+	}
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "descendant", map[string]interface{}{
+		"greeting": "World",
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	expect := `<h1>Hello World! from ancestor</h1>`
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -2,7 +2,6 @@ package django
 
 import (
 	"bytes"
-	"embed"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -109,29 +108,6 @@ func Test_FileSystem(t *testing.T) {
 	}
 }
 
-//go:embed views
-var viewsAsssets embed.FS
-
-func Test_PathForwardingFileSystem(t *testing.T) {
-	engine := NewPathForwardingFileSystem(http.FS(viewsAsssets), "/views", ".django")
-	engine.Debug(true)
-	if err := engine.Load(); err != nil {
-		t.Fatalf("load: %v\n", err)
-	}
-
-	var buf bytes.Buffer
-	err := engine.Render(&buf, "descendant", map[string]interface{}{
-		"greeting": "World",
-	})
-	if err != nil {
-		t.Fatalf("render: %v", err)
-	}
-	expect := `<h1>Hello World! from ancestor</h1>`
-	result := trim(buf.String())
-	if expect != result {
-		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
-	}
-}
 
 func Test_AddFunc(t *testing.T) {
 	engine := NewFileSystem(http.Dir("./views"), ".django")

--- a/django/views/ancestor.django
+++ b/django/views/ancestor.django
@@ -1,0 +1,1 @@
+<h1>Hello {% block content %}{% endblock %}! from ancestor</h1>

--- a/django/views/descendant.django
+++ b/django/views/descendant.django
@@ -1,0 +1,3 @@
+{% extends "ancestor.django" %}
+
+{% block content %}{{ greeting }}{% endblock %}


### PR DESCRIPTION
Add option to allow passing view base path to django templating engine. When the path is not specified, resolution of inherited templates fails.

Also, one wrong assumption that was made was that everyone is going to use the same directory structure. Not good.  