### PR TITLE
Fix issue with variable bindings missing in layouts for Handlebars & Mustache engines

### DIFF
--- a/handlebars/handlebars.go
+++ b/handlebars/handlebars.go
@@ -199,7 +199,7 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 		if lay == nil {
 			return fmt.Errorf("render: layout %s does not exist", layout[0])
 		}
-		bind := make(map[string]interface{})
+		var bind map[string]interface{}
 		if m, ok := binding.(fiber.Map); ok {
 			bind = m
 		} else if m, ok := binding.(map[string]interface{}); ok {

--- a/handlebars/handlebars.go
+++ b/handlebars/handlebars.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 
 	"github.com/aymerick/raymond"
+	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/template/utils"
 )
 
@@ -200,14 +200,12 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 			return fmt.Errorf("render: layout %s does not exist", layout[0])
 		}
 		bind := make(map[string]interface{})
-		if binding != nil {
-			val := reflect.ValueOf(binding)
-			if val.Kind() == reflect.Map {
-				for _, e := range val.MapKeys() {
-					v := val.MapIndex(e)
-					bind[e.String()] = v.Interface()
-				}
-			}
+		if m, ok := binding.(fiber.Map); ok {
+			bind = m
+		} else if m, ok := binding.(map[string]interface{}); ok {
+			bind = m
+		} else {
+			bind = make(map[string]interface{}, 1)
 		}
 		bind[e.layout] = raymond.SafeString(parsed)
 		parsed, err := lay.Exec(bind)

--- a/handlebars/handlebars_test.go
+++ b/handlebars/handlebars_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 func trim(str string) string {
@@ -24,7 +26,7 @@ func Test_Render(t *testing.T) {
 	}
 	// Partials
 	var buf bytes.Buffer
-	engine.Render(&buf, "index", map[string]interface{}{
+	engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	})
 	expect := `<h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2>`
@@ -34,7 +36,7 @@ func Test_Render(t *testing.T) {
 	}
 	// Single
 	buf.Reset()
-	engine.Render(&buf, "errors/404", map[string]interface{}{
+	engine.Render(&buf, "errors/404", fiber.Map{
 		"Title": "Hello, World!",
 	})
 	expect = `<h1>Hello, World!</h1>`
@@ -52,10 +54,10 @@ func Test_Layout(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	engine.Render(&buf, "index", map[string]interface{}{
+	engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	}, "layouts/main")
-	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	expect := `<!DOCTYPE html><html><head><title>Hello, World!</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
@@ -70,7 +72,7 @@ func Test_Empty_Layout(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	engine.Render(&buf, "index", map[string]interface{}{
+	engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	}, "")
 	expect := `<h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2>`
@@ -89,10 +91,10 @@ func Test_FileSystem(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	engine.Render(&buf, "index", map[string]interface{}{
+	engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	}, "layouts/main")
-	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	expect := `<!DOCTYPE html><html><head><title>Hello, World!</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/handlebars/views/layouts/main.hbs
+++ b/handlebars/views/layouts/main.hbs
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>Main</title>
+  <title>{{Title}}</title>
 </head>
 
 <body>

--- a/mustache/mustache.go
+++ b/mustache/mustache.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 
 	"github.com/cbroglie/mustache"
+	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/template/utils"
 	"github.com/valyala/bytebufferpool"
 )
@@ -200,14 +200,12 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 			return err
 		}
 		bind := make(map[string]interface{})
-		if binding != nil {
-			val := reflect.ValueOf(binding)
-			if val.Kind() == reflect.Map {
-				for _, e := range val.MapKeys() {
-					v := val.MapIndex(e)
-					bind[e.String()] = v.Interface()
-				}
-			}
+		if m, ok := binding.(fiber.Map); ok {
+			bind = m
+		} else if m, ok := binding.(map[string]interface{}); ok {
+			bind = m
+		} else {
+			bind = make(map[string]interface{}, 1)
 		}
 		bind[e.layout] = buf.String()
 		lay := e.Templates[layout[0]]

--- a/mustache/mustache.go
+++ b/mustache/mustache.go
@@ -199,7 +199,7 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 		if err := tmpl.FRender(buf, binding); err != nil {
 			return err
 		}
-		bind := make(map[string]interface{})
+		var bind map[string]interface{}
 		if m, ok := binding.(fiber.Map); ok {
 			bind = m
 		} else if m, ok := binding.(map[string]interface{}); ok {

--- a/mustache/mustache_test.go
+++ b/mustache/mustache_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 func trim(str string) string {
@@ -23,7 +25,7 @@ func Test_Render(t *testing.T) {
 	}
 	// Partials
 	var buf bytes.Buffer
-	engine.Render(&buf, "index", map[string]interface{}{
+	engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	})
 	expect := `<h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2>`
@@ -33,7 +35,7 @@ func Test_Render(t *testing.T) {
 	}
 	// Single
 	buf.Reset()
-	engine.Render(&buf, "errors/404", map[string]interface{}{
+	engine.Render(&buf, "errors/404", fiber.Map{
 		"Title": "Hello, World!",
 	})
 	expect = `<h1>Hello, World!</h1>`
@@ -50,13 +52,13 @@ func Test_Layout(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := engine.Render(&buf, "index", map[string]interface{}{
+	err := engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	}, "layouts/main")
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
-	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	expect := `<!DOCTYPE html><html><head><title>Hello, World!</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
@@ -70,7 +72,7 @@ func Test_Empty_Layout(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := engine.Render(&buf, "index", map[string]interface{}{
+	err := engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	}, "")
 	if err != nil {
@@ -90,13 +92,13 @@ func Test_FileSystem(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := engine.Render(&buf, "index", map[string]interface{}{
+	err := engine.Render(&buf, "index", fiber.Map{
 		"Title": "Hello, World!",
 	}, "layouts/main")
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
-	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
+	expect := `<!DOCTYPE html><html><head><title>Hello, World!</title></head><body><h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2></body></html>`
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)

--- a/mustache/views/layouts/main.mustache
+++ b/mustache/views/layouts/main.mustache
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>Main</title>
+  <title>{{Title}}</title>
 </head>
 
 <body>


### PR DESCRIPTION
This pull request resolves the following issues:
https://github.com/gofiber/template/issues/157
https://github.com/gofiber/template/issues/201

Summary of issue: 
Variable bindings that were available when the view is rendered, were not available when the layout is rendered. The root cause appeared to be a failing type assertion from a type `fiber.Map` to a type `map[string]interface{}`.  This assertion would always fail when rendering a template with a layout. When the assertion fails, a new map is created and the variable bindings are lost.

Summary of fix:
I have taken a generic approach and used the reflect package to iterate over the Map and assign the variables bindings as concrete values to a new map. This removed the need for the type assertion. We could however continue to do the type assertion using `fiber.Map` instead but I thought you might want to make these packages more generic. I have also updated the tests to pass the view variables as type `fiber.Map` to match the data type passed by the Fiber App.

These lines are the respective type assertions that were failing:
https://github.com/gofiber/template/blob/master/handlebars/handlebars.go#L202
https://github.com/gofiber/template/blob/master/mustache/mustache.go#L204