### PR TITLE
Don't rebind custom helpers on Engine Reload (Handlebars)

### DIFF
--- a/handlebars/handlebars.go
+++ b/handlebars/handlebars.go
@@ -109,7 +109,10 @@ func (e *Engine) Load() (err error) {
 	defer e.mutex.Unlock()
 	// Set template settings
 	e.Templates = make(map[string]*raymond.Template)
-	raymond.RegisterHelpers(e.funcmap)
+
+	if !e.loaded {
+		raymond.RegisterHelpers(e.funcmap)
+	}
 	// Loop trough each directory and register template files
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		// Return error if exist
@@ -178,9 +181,6 @@ func (e *Engine) Load() (err error) {
 // Execute will render the template by name
 func (e *Engine) Render(out io.Writer, template string, binding interface{}, layout ...string) error {
 	if !e.loaded || e.reload {
-		if e.reload {
-			e.loaded = false
-		}
 		if err := e.Load(); err != nil {
 			return err
 		}

--- a/handlebars/handlebars_test.go
+++ b/handlebars/handlebars_test.go
@@ -103,6 +103,11 @@ func Test_Reload(t *testing.T) {
 	engine := NewFileSystem(http.Dir("./views"), ".hbs")
 	engine.Reload(true) // Optional. Default: false
 
+	// Test Load() does not re-bind custom helpers
+	engine.AddFunc("testHelper", func(s string) string {
+		return "Hello World"
+	})
+
 	if err := engine.Load(); err != nil {
 		t.Fatalf("load: %v\n", err)
 	}


### PR DESCRIPTION
This pull request fixes this issue:
https://github.com/gofiber/template/issues/197

Summary of issue:
When setting Reload to `true` in the Handlebars engine config, custom helpers would get re-registered on each render and this would cause a panic with an error of "Helper already registered".

Summary of fix:
There was an unused variable called `loaded` which was being set to false in the Render method during reload.  This was removed from the Render function (it wasn't being used) and we instead use it to check if Helpers are already registered when we load the templates in the Load function. I also added a custom helper to the reload tests so we can check for this condition in the future.

