### PR TITLE
Ensure we bind custom helpers only once on Engine Reload (Handlebars)

### DIFF
--- a/handlebars/handlebars.go
+++ b/handlebars/handlebars.go
@@ -32,6 +32,8 @@ type Engine struct {
 	debug bool
 	// lock for funcmap and templates
 	mutex sync.RWMutex
+	// object to bind custom helpers once
+	registerHelpersOnce sync.Once
 	// template funcmap
 	funcmap map[string]interface{}
 	// templates
@@ -110,7 +112,9 @@ func (e *Engine) Load() (err error) {
 	defer e.mutex.Unlock()
 	// Set template settings
 	e.Templates = make(map[string]*raymond.Template)
-	raymond.RegisterHelpers(e.funcmap)
+	e.registerHelpersOnce.Do(func() {
+		raymond.RegisterHelpers(e.funcmap)
+	})
 	// Loop trough each directory and register template files
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		// Return error if exist

--- a/handlebars/handlebars_test.go
+++ b/handlebars/handlebars_test.go
@@ -105,6 +105,11 @@ func Test_Reload(t *testing.T) {
 	engine := NewFileSystem(http.Dir("./views"), ".hbs")
 	engine.Reload(true) // Optional. Default: false
 
+	// Test Load() does not re-bind custom helpers
+	engine.AddFunc("testHelper", func() string {
+		return "Hello World"
+	})
+
 	if err := engine.Load(); err != nil {
 		t.Fatalf("load: %v\n", err)
 	}


### PR DESCRIPTION
This is the updated PR from code review here: https://github.com/gofiber/template/pull/205

Fixes: https://github.com/gofiber/template/issues/197