### PR TITLE
html: Add method `FuncMap()` to export function map.

### DIFF
--- a/html/html.go
+++ b/html/html.go
@@ -56,7 +56,7 @@ func New(directory, extension string) *Engine {
 	return engine
 }
 
-//NewFileSystem ...
+// NewFileSystem ...
 func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 	engine := &Engine{
 		left:       "{{",
@@ -222,4 +222,9 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 		return lay.Execute(out, binding)
 	}
 	return tmpl.Execute(out, binding)
+}
+
+// FuncMap returns the template's function map.
+func (e *Engine) FuncMap() map[string]interface{} {
+	return e.funcmap
 }

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -77,6 +77,12 @@ func Test_AddFunc(t *testing.T) {
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
 	}
+
+	// FuncMap
+	fm := engine.FuncMap()
+	if _, ok := fm["isAdmin"]; !ok {
+		t.Fatalf("Function isAdmin does not exist in FuncMap().\n")
+	}
 }
 
 func Test_AddFuncMap(t *testing.T) {
@@ -113,6 +119,15 @@ func Test_AddFuncMap(t *testing.T) {
 	result := trim(buf.String())
 	if expect != result {
 		t.Fatalf("Expected:\n%s\nResult:\n%s\n", expect, result)
+	}
+
+	// FuncMap
+	fm2 := engine.FuncMap()
+	if _, ok := fm2["lower"]; !ok {
+		t.Fatalf("Function lower does not exist in FuncMap().\n")
+	}
+	if _, ok := fm2["upper"]; !ok {
+		t.Fatalf("Function upper does not exist in FuncMap().\n")
 	}
 }
 


### PR DESCRIPTION
Sometimes we need registered function map, but `html` package doesn't export it. This PR adds method `FuncMap()` for this purpose.