### PR TITLE
:pencil2: feature: add FuncMap to Slim engine

### DIFF
--- a/slim/slim.go
+++ b/slim/slim.go
@@ -37,10 +37,12 @@ type Engine struct {
 	// lock for funcmap and templates
 	mutex sync.RWMutex
 	// template funcmap
-	funcmap map[string]interface{}
+	funcMap map[string]interface{}
 	// templates
 	Templates map[string]*slim.Template
 }
+
+type slimFunc = func(...slim.Value) (slim.Value, error)
 
 // New returns a Slim render engine for Fiber
 func New(directory, extension string) *Engine {
@@ -50,7 +52,7 @@ func New(directory, extension string) *Engine {
 		directory: directory,
 		extension: extension,
 		layout:    "embed",
-		funcmap:   make(map[string]interface{}),
+		funcMap:   make(map[string]interface{}),
 	}
 	return engine
 }
@@ -63,7 +65,7 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 		fileSystem: fs,
 		extension:  extension,
 		layout:     "embed",
-		funcmap:    make(map[string]interface{}),
+		funcMap:    make(map[string]interface{}),
 	}
 	return engine
 }
@@ -86,7 +88,7 @@ func (e *Engine) Delims(left, right string) *Engine {
 // It is legal to overwrite elements of the default actions
 func (e *Engine) AddFunc(name string, fn interface{}) *Engine {
 	e.mutex.Lock()
-	e.funcmap[name] = fn
+	e.funcMap[name] = fn
 	e.mutex.Unlock()
 	return e
 }
@@ -96,7 +98,7 @@ func (e *Engine) AddFunc(name string, fn interface{}) *Engine {
 func (e *Engine) AddFuncMap(m map[string]interface{}) *Engine {
 	e.mutex.Lock()
 	for name, fn := range m {
-		e.funcmap[name] = fn
+		e.funcMap[name] = fn
 	}
 	e.mutex.Unlock()
 	return e
@@ -114,12 +116,6 @@ func (e *Engine) Reload(enabled bool) *Engine {
 func (e *Engine) Debug(enabled bool) *Engine {
 	e.debug = enabled
 	return e
-}
-
-// Parse is deprecated, please use Load() instead
-func (e *Engine) Parse() error {
-	fmt.Println("Parse() is deprecated, please use Load() instead.")
-	return e.Load()
 }
 
 // Load parses the templates to the engine.
@@ -166,7 +162,18 @@ func (e *Engine) Load() error {
 		if err != nil {
 			return err
 		}
-		// tmpl.FuncMap(e.funcmap)
+
+		// Init func map
+		newFuncMap := make(slim.Funcs, len(e.funcMap))
+		for key, val := range e.funcMap {
+			slimFunc, ok := val.(slimFunc)
+			if !ok {
+				panic("slim: function must be compatible with slim.Func type. Slim does not support other types")
+			}
+			newFuncMap[key] = slimFunc
+		}
+		tmpl.FuncMap(newFuncMap)
+
 		e.Templates[name] = tmpl
 		// Debugging
 		if e.debug {
@@ -218,4 +225,9 @@ func (e *Engine) Render(out io.Writer, template string, binding interface{}, lay
 		return lay.Execute(out, bind)
 	}
 	return tmpl.Execute(out, binding)
+}
+
+// FuncMap returns the template's function map.
+func (e *Engine) FuncMap() map[string]interface{} {
+	return e.funcMap
 }


### PR DESCRIPTION
This PR adds funcmap to Slim that wasn't added in the past.

Slim doesn't seem to support `map[string]interface{}` type for funcMap. So we have to change type of funcMap or assert interface to slim function. I prefered asserting not to break compatibility with other engines. 