### PR TITLE
fix: django only ValidIdentifiers

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -181,3 +181,9 @@ Hello, World!<br /><br />Greetings from Fiber Team
 </body>
 </html>
 ```
+
+### Important Information on Template Data Binding
+
+When working with Pongo2 and this template engine, it's crucial to understand the specific rules for data binding. Only keys that match the following regular expression are supported: `^[a-zA-Z0-9_]+$`.
+
+This means that keys with special characters or punctuation, such as `my-key` or `my.key`, are not compatible and will not be bound to the template. This is a restriction imposed by the underlying Pongo2 template engine. Please ensure your keys adhere to these rules to avoid any binding issues.

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -4,12 +4,13 @@ package django
 import (
 	"bytes"
 	"embed"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -74,6 +75,23 @@ func Test_Empty_Layout(t *testing.T) {
 	var buf bytes.Buffer
 	err := engine.Render(&buf, "index", map[string]interface{}{
 		"Title": "Hello, World!",
+	}, "")
+	require.NoError(t, err)
+
+	expect := `<h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2>`
+	result := trim(buf.String())
+	require.Equal(t, expect, result)
+}
+
+func Test_Invalid_Identifiers(t *testing.T) {
+	engine := New("./views", ".django")
+	engine.Debug(true)
+	require.NoError(t, engine.Load())
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "index", map[string]interface{}{
+		"Title":               "Hello, World!",
+		"Invalid.Identifiers": "Don't return error from checkForValidIdentifiers!",
 	}, "")
 	require.NoError(t, err)
 


### PR DESCRIPTION
This pull request focuses on enhancing the exclusion of invalid identifiers in the getPongoBinding function within the django template. The changes include:

- The createBindFromMap function now checks for valid identifiers and skips any invalid ones.
- Added new unit tests to ensure that invalid identifiers are not passed to Pongo2

Fixes https://github.com/gofiber/fiber/issues/2682