### PR TITLE
fix: django template invalid keys efficiency

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -181,3 +181,9 @@ Hello, World!<br /><br />Greetings from Fiber Team
 </body>
 </html>
 ```
+
+### Important Information on Template Data Binding
+
+When working with Pongo2 and this template engine, it's crucial to understand the specific rules for data binding. Only keys that match the following regular expression are supported: `^[a-zA-Z0-9_]+$`.
+
+This means that keys with special characters or punctuation, such as `my-key` or `my.key`, are not compatible and will not be bound to the template. This is a restriction imposed by the underlying Pongo2 template engine. Please ensure your keys adhere to these rules to avoid any binding issues.

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -4,12 +4,13 @@ package django
 import (
 	"bytes"
 	"embed"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -74,6 +75,23 @@ func Test_Empty_Layout(t *testing.T) {
 	var buf bytes.Buffer
 	err := engine.Render(&buf, "index", map[string]interface{}{
 		"Title": "Hello, World!",
+	}, "")
+	require.NoError(t, err)
+
+	expect := `<h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2>`
+	result := trim(buf.String())
+	require.Equal(t, expect, result)
+}
+
+func Test_Invalid_Identifiers(t *testing.T) {
+	engine := New("./views", ".django")
+	engine.Debug(true)
+	require.NoError(t, engine.Load())
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "index", map[string]interface{}{
+		"Title":               "Hello, World!",
+		"Invalid.Identifiers": "Don't return error from checkForValidIdentifiers!",
 	}, "")
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR aims to improve the efficiency of invalidKey checking in the django template.

## Benchmarks

<details>
<summary>Before PR</summary>

| Benchmark             | Test Name               | Iterations  | Avg Time   | Avg Memory    | Avg Allocations  |
|-----------------------|-------------------------|-------------|------------|--------------|------------------|
| Benchmark_Django      | simple-12               | 1771390     | 661.4 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1825515     | 659.5 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1809768     | 662.8 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1812396     | 662.9 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended-12           | 337903      | 3434 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 338953      | 3455 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 334182      | 3480 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 335949      | 3447 ns/op | 3955 B/op   | 37 allocs/op     |
| **Averages (Before PR)** |                  |             |            |              |                  |
| Benchmark_Django      | simple                  | 1792267.25  | 661.65 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended                | 336996.75   | 3454 ns/op | 3955 B/op   | 37 allocs/op     |

</details>

<details>
<summary>After PR</summary>

| Benchmark             | Test Name               | Iterations  | Avg Time   | Avg Memory    | Avg Allocations  |
|-----------------------|-------------------------|-------------|------------|--------------|------------------|
| Benchmark_Django      | simple-12               | 1694342     | 685.9 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1742577     | 688.6 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1744773     | 690.6 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1735177     | 688.0 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended-12           | 335431      | 3445 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 344763      | 3457 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 320379      | 3464 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 334527      | 3449 ns/op | 3955 B/op   | 37 allocs/op     |
| **Averages (After PR)** |                   |             |            |              |                  |
| Benchmark_Django      | simple                  | 1734192.25   | 688.75 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended                | 333275.0    | 3454.25 ns/op | 3955 B/op   | 37 allocs/op     |

</details>

<details>
<summary>Comparison</summary>

| Benchmark             | Test Name               | Avg Time Difference  | Avg Memory Difference  | Avg Allocations Difference |
|-----------------------|-------------------------|-----------------------|-------------------------|-----------------------------|
| Benchmark_Django      | simple                  | 27.1 ns/op       | 0 B/op                 | 0 allocs/op                |
| Benchmark_Django/extended| extended                | 0.25 ns/op         | 0 B/op                 | 0 allocs/op                |

</details>

