### PR TITLE
fix: django template invalid keys efficiency

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -187,3 +187,11 @@ Hello, World!<br /><br />Greetings from Fiber Team
 When working with Pongo2 and this template engine, it's crucial to understand the specific rules for data binding. Only keys that match the following regular expression are supported: `^[a-zA-Z0-9_]+$`.
 
 This means that keys with special characters or punctuation, such as `my-key` or `my.key`, are not compatible and will not be bound to the template. This is a restriction imposed by the underlying Pongo2 template engine. Please ensure your keys adhere to these rules to avoid any binding issues.
+
+If you need to access a value in the template that doesn't adhere to the key naming restrictions imposed by the Pongo2 template engine, you can bind the value to a new field when calling `fiber.Render`. Here's an example:
+
+```go
+c.Render("index", fiber.Map{
+    "Fiber": "Hello, World!\n\nGreetings from Fiber Team",
+    "MyKey": c.Locals("my-key"),
+})

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -4,12 +4,17 @@ package django
 import (
 	"bytes"
 	"embed"
+	"math/rand"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+	"unicode"
 
+	"github.com/flosch/pongo2/v6"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,6 +103,68 @@ func Test_Invalid_Identifiers(t *testing.T) {
 	expect := `<h2>Header</h2><h1>Hello, World!</h1><h2>Footer</h2>`
 	result := trim(buf.String())
 	require.Equal(t, expect, result)
+}
+
+func Test_GetPongoBinding(t *testing.T) {
+	// Test with pongo2.Context
+	ctx := pongo2.Context{"key1": "value1"}
+	result := getPongoBinding(ctx)
+	assert.Equal(t, ctx, result, "Expected the same context")
+
+	// Test with map[string]interface{}
+	mapBinding := map[string]interface{}{"key2": "value2"}
+	result = getPongoBinding(mapBinding)
+	assert.Equal(t, pongo2.Context(mapBinding), result, "Expected the same context")
+
+	// Test with fiber.Map
+	fiberMap := fiber.Map{"key3": "value3"}
+	result = getPongoBinding(fiberMap)
+	assert.Equal(t, pongo2.Context(fiberMap), result, "Expected the same context")
+
+	// Test with unsupported type
+	result = getPongoBinding("unsupported")
+	assert.Nil(t, result, "Expected nil for unsupported type")
+
+	// Test with invalid key
+	invalidCtx := pongo2.Context{"key1": "value1", "invalid.key": "value2"}
+	result = getPongoBinding(invalidCtx)
+	assert.Equal(t, pongo2.Context{"key1": "value1"}, result, "Expected the same context")
+}
+
+func Test_IsValidKey(t *testing.T) {
+	assert.True(t, isValidKey("key1"), "Expected true for valid key")
+	assert.False(t, isValidKey("invalid.key"), "Expected false for invalid key")
+	assert.False(t, isValidKey("invalid-key"), "Expected false for invalid key")
+	assert.False(t, isValidKey("key1\n"), "Expected false for invalid key")
+	assert.False(t, isValidKey("key1 "), "Expected false for invalid key")
+	assert.False(t, isValidKey("👍"), "Expected false for invalid key")
+	assert.False(t, isValidKey("你好"), "Expected false for invalid key")
+
+	// do sume fuzzing where we generate 1000 random strings and check if they are valid keys
+	// valid keys match the following regex: [a-zA-Z0-9_]+
+	reValidkeys := regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	for i := 0; i < 1000; i++ {
+		key := generateRandomString(10)
+		assert.Equal(t, reValidkeys.MatchString(key), isValidKey(key), "Expected the same result for key")
+	}
+}
+
+// generateRandomString generates a random string of length n
+// with printable, non-whitespace characters
+//
+// helper function for Test_IsValidKey
+func generateRandomString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		for {
+			c := rune(rand.Intn(0x10FFFF))                 // generate a random rune
+			if !unicode.IsSpace(c) && unicode.IsPrint(c) { // check if it's a printable, non-whitespace character
+				b[i] = c
+				break
+			}
+		}
+	}
+	return string(b)
 }
 
 func Test_FileSystem(t *testing.T) {
@@ -226,6 +293,24 @@ func Test_AddFuncMap(t *testing.T) {
 	require.True(t, ok)
 }
 
+func Test_Invalid_Template(t *testing.T) {
+	engine := New("./views", ".django")
+	require.NoError(t, engine.Load())
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "invalid", nil)
+	require.Error(t, err)
+}
+
+func Test_Invalid_Layout(t *testing.T) {
+	engine := New("./views", ".django")
+	require.NoError(t, engine.Load())
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "index", nil, "invalid")
+	require.Error(t, err)
+}
+
 func Benchmark_Django(b *testing.B) {
 	expectSimple := `<h1>Hello, World!</h1>`
 	expectExtended := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, Admin!</h1><h2>Footer</h2></body></html>`
@@ -258,6 +343,36 @@ func Benchmark_Django(b *testing.B) {
 			buf.Reset()
 			err = engine.Render(&buf, "extended", map[string]interface{}{
 				"User": admin,
+			}, "layouts/main")
+		}
+
+		require.NoError(b, err)
+		require.Equal(b, expectExtended, trim(buf.String()))
+	})
+
+	b.Run("simple_with_invalid_binding_keys", func(bb *testing.B) {
+		bb.ReportAllocs()
+		bb.ResetTimer()
+		for i := 0; i < bb.N; i++ {
+			buf.Reset()
+			err = engine.Render(&buf, "simple", map[string]interface{}{
+				"Title":       "Hello, World!",
+				"Invalid_Key": "Don't return error from checkForValidIdentifiers!",
+			})
+		}
+
+		require.NoError(b, err)
+		require.Equal(b, expectSimple, trim(buf.String()))
+	})
+
+	b.Run("extended_with_invalid_binding_keys", func(bb *testing.B) {
+		bb.ReportAllocs()
+		bb.ResetTimer()
+		for i := 0; i < bb.N; i++ {
+			buf.Reset()
+			err = engine.Render(&buf, "extended", map[string]interface{}{
+				"User":        admin,
+				"Invalid_Key": "Don't return error from checkForValidIdentifiers!",
 			}, "layouts/main")
 		}
 


### PR DESCRIPTION
Aims to improve performance of the elimination of invalid keys from django template.

This is a follow up to #307 which used a regex for the same purpose.

## Benchmarks

<details>
<summary>Before [PR#307]</summary>

| Benchmark             | Test Name               | Iterations  | Avg Time   | Avg Memory    | Avg Allocations  |
|-----------------------|-------------------------|-------------|------------|--------------|------------------|
| Benchmark_Django      | simple-12               | 1771390     | 661.4 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1825515     | 659.5 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1809768     | 662.8 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1812396     | 662.9 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended-12           | 337903      | 3434 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 338953      | 3455 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 334182      | 3480 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 335949      | 3447 ns/op | 3955 B/op   | 37 allocs/op     |
| **Averages (Before PR)** |                  |             |            |              |                  |
| Benchmark_Django      | simple                  | 1792267.25  | 661.65 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended                | 336996.75   | 3454 ns/op | 3955 B/op   | 37 allocs/op     |

</details>

<details>
<summary>This PR</summary>

| Benchmark             | Test Name               | Iterations  | Avg Time   | Avg Memory    | Avg Allocations  |
|-----------------------|-------------------------|-------------|------------|--------------|------------------|
| Benchmark_Django      | simple-12               | 1694342     | 685.9 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1742577     | 688.6 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1744773     | 690.6 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django      | simple-12               | 1735177     | 688.0 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended-12           | 335431      | 3445 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 344763      | 3457 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 320379      | 3464 ns/op | 3955 B/op   | 37 allocs/op     |
| Benchmark_Django/extended| extended-12           | 334527      | 3449 ns/op | 3955 B/op   | 37 allocs/op     |
| **Averages (After PR)** |                   |             |            |              |                  |
| Benchmark_Django      | simple                  | 1734192.25   | 688.75 ns/op| 880 B/op    | 10 allocs/op     |
| Benchmark_Django/extended| extended                | 333275.0    | 3454.25 ns/op | 3955 B/op   | 37 allocs/op     |

</details>

<details>
<summary>Comparison</summary>

| Benchmark             | Test Name               | Avg Time Difference  | Avg Memory Difference  | Avg Allocations Difference |
|-----------------------|-------------------------|-----------------------|-------------------------|-----------------------------|
| Benchmark_Django      | simple                  | 27.1 ns/op       | 0 B/op                 | 0 allocs/op                |
| Benchmark_Django/extended| extended                | 0.25 ns/op         | 0 B/op                 | 0 allocs/op                |

</details>
