### PR TITLE
fix: Django autoescape should be enable by default

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -227,7 +227,7 @@ engine.SetAutoEscape(false)
 - It can also be done on a per variable basis using the *safe* built-in:
 ```django
 <h1>{{ someSafeVar | safe }}</h1>
-{{ "<script>"|safe }}
+{{ "<script>" | safe }}
 ```
 
 ### Security Implications of Disabling Auto-Escape

--- a/django/README.md
+++ b/django/README.md
@@ -209,6 +209,27 @@ engine := django.New("./views", ".django")
 engine.SetAutoEscape(false)
 ```
 
+### Setting AutoEscape using Django built-in template tags
+
+- Explicitly turning off autoescaping for a section:
+```django  
+  {% autoescape off %}
+  {{ "<script>alert('Hello World');</script>" }}
+  {% endautoescape %}
+```
+
+- Turning autoescaping back on for a section:
+```django
+  {% autoescape on %}
+  {{ "<script>alert('Hello World');</script>" }}
+  {% endautoescape %}
+```
+- It can also be done on a per variable basis using the *safe* built-in:
+```django
+<h1>{{ someSafeVar | safe }}</h1>
+{{ "<script>"|safe }}
+```
+
 ### Security Implications of Disabling Auto-Escape
 
 Disabling auto-escape should be approached with caution. It can expose your application to XSS attacks, where malicious scripts are injected into web pages. Without auto-escaping, there is a risk of rendering harmful HTML or JavaScript from user-supplied data.

--- a/django/README.md
+++ b/django/README.md
@@ -59,9 +59,9 @@ func main() {
 	// Create a new engine
 	engine := django.New("./views", ".django")
 
-  // Or from an embedded system
-  // See github.com/gofiber/embed for examples
-  // engine := html.NewFileSystem(http.Dir("./views", ".django"))
+	// Or from an embedded system
+	// See github.com/gofiber/embed for examples
+	// engine := html.NewFileSystem(http.Dir("./views", ".django"))
 
 	// Pass the engine to the Views
 	app := fiber.New(fiber.Config{
@@ -195,3 +195,22 @@ c.Render("index", fiber.Map{
     "Fiber": "Hello, World!\n\nGreetings from Fiber Team",
     "MyKey": c.Locals("my-key"),
 })
+
+### AutoEscape is enabled by default
+
+When you create a new instance of the `Engine`, the auto-escape is **enabled by default**. This setting automatically escapes output, providing a critical security measure against Cross-Site Scripting (XSS) attacks.
+
+### Disabling Auto-Escape
+
+Auto-escaping can be disabled if necessary, using the `SetAutoEscape` method:
+
+```go
+engine := django.New("./views", ".django")
+engine.SetAutoEscape(false)
+```
+
+### Security Implications of Disabling Auto-Escape
+
+Disabling auto-escape should be approached with caution. It can expose your application to XSS attacks, where malicious scripts are injected into web pages. Without auto-escaping, there is a risk of rendering harmful HTML or JavaScript from user-supplied data.
+
+It is advisable to keep auto-escape enabled unless there is a strong reason to disable it. If you do disable it, ensure all user-supplied content is thoroughly sanitized and validated to avoid XSS vulnerabilities.

--- a/django/django.go
+++ b/django/django.go
@@ -232,7 +232,16 @@ func (e *Engine) Render(out io.Writer, name string, binding interface{}, layout 
 		if bind == nil {
 			bind = make(map[string]interface{}, 1)
 		}
-		bind[e.LayoutName] = parsed
+
+		// Wrokaround for custom {{embed}} tag
+		// Mark the `embed` variable as safe
+		// it has already been escaped above
+		// e.LayoutName will be 'embed'
+		safeEmbed := pongo2.AsSafeValue(parsed)
+
+		// Add the safe value to the binding map
+		bind[e.LayoutName] = safeEmbed
+
 		lay := e.Templates[layout[0]]
 		if lay == nil {
 			return fmt.Errorf("LayoutName %s does not exist", layout[0])

--- a/django/django.go
+++ b/django/django.go
@@ -21,10 +21,10 @@ type Engine struct {
 	core.Engine
 	// forward the base path to the template Engine
 	forwardPath bool
+	// set auto escape globally
+	autoEscape bool
 	// templates
 	Templates map[string]*pongo2.Template
-	// set auto escape globally
-	AutoEscape bool
 }
 
 // New returns a Django render engine for Fiber
@@ -38,7 +38,7 @@ func New(directory, extension string) *Engine {
 			LayoutName: "embed",
 			Funcmap:    make(map[string]interface{}),
 		},
-		AutoEscape: true,
+		autoEscape: true,
 	}
 	return engine
 }
@@ -55,7 +55,7 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 			LayoutName: "embed",
 			Funcmap:    make(map[string]interface{}),
 		},
-		AutoEscape: true,
+		autoEscape: true,
 	}
 	return engine
 }
@@ -74,7 +74,7 @@ func NewPathForwardingFileSystem(fs http.FileSystem, directory, extension string
 			LayoutName: "embed",
 			Funcmap:    make(map[string]interface{}),
 		},
-		AutoEscape: true,
+		autoEscape: true,
 		forwardPath: true,
 	}
 	return engine
@@ -107,7 +107,7 @@ func (e *Engine) Load() error {
 	// Set template settings
 	pongoset.Globals.Update(e.Funcmap)
 	// Set autoescaping
-	pongo2.SetAutoescape(e.AutoEscape)
+	pongo2.SetAutoescape(e.autoEscape)
 
 	// Loop trough each Directory and register template files
 	walkFn := func(path string, info os.FileInfo, err error) error {
@@ -215,7 +215,7 @@ func isValidKey(key string) bool {
 
 // SetAutoEscape sets the auto-escape property of the template engine
 func (e *Engine) SetAutoEscape(autoEscape bool) {
-	e.AutoEscape = autoEscape
+	e.autoEscape = autoEscape
 }
 
 // Render will render the template by name

--- a/django/django.go
+++ b/django/django.go
@@ -23,6 +23,8 @@ type Engine struct {
 	forwardPath bool
 	// templates
 	Templates map[string]*pongo2.Template
+	// set auto escape globally
+	AutoEscape bool
 }
 
 // New returns a Django render engine for Fiber
@@ -36,6 +38,7 @@ func New(directory, extension string) *Engine {
 			LayoutName: "embed",
 			Funcmap:    make(map[string]interface{}),
 		},
+		AutoEscape: true,
 	}
 	return engine
 }
@@ -52,6 +55,7 @@ func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 			LayoutName: "embed",
 			Funcmap:    make(map[string]interface{}),
 		},
+		AutoEscape: true,
 	}
 	return engine
 }
@@ -70,6 +74,7 @@ func NewPathForwardingFileSystem(fs http.FileSystem, directory, extension string
 			LayoutName: "embed",
 			Funcmap:    make(map[string]interface{}),
 		},
+		AutoEscape: true,
 		forwardPath: true,
 	}
 	return engine
@@ -101,8 +106,8 @@ func (e *Engine) Load() error {
 	pongoset := pongo2.NewSet("default", pongoloader)
 	// Set template settings
 	pongoset.Globals.Update(e.Funcmap)
-	// Enable autoescaping
-	pongo2.SetAutoescape(true)
+	// Set autoescaping
+	pongo2.SetAutoescape(e.AutoEscape)
 
 	// Loop trough each Directory and register template files
 	walkFn := func(path string, info os.FileInfo, err error) error {
@@ -206,6 +211,11 @@ func isValidKey(key string) bool {
 		}
 	}
 	return true
+}
+
+// SetAutoEscape sets the auto-escape property of the template engine
+func (e *Engine) SetAutoEscape(autoEscape bool) {
+	e.AutoEscape = autoEscape
 }
 
 // Render will render the template by name

--- a/django/django.go
+++ b/django/django.go
@@ -233,7 +233,7 @@ func (e *Engine) Render(out io.Writer, name string, binding interface{}, layout 
 			bind = make(map[string]interface{}, 1)
 		}
 
-		// Wrokaround for custom {{embed}} tag
+		// Workaround for custom {{embed}} tag
 		// Mark the `embed` variable as safe
 		// it has already been escaped above
 		// e.LayoutName will be 'embed'

--- a/django/django.go
+++ b/django/django.go
@@ -101,7 +101,8 @@ func (e *Engine) Load() error {
 	pongoset := pongo2.NewSet("default", pongoloader)
 	// Set template settings
 	pongoset.Globals.Update(e.Funcmap)
-	pongo2.SetAutoescape(false)
+	// Enable autoescaping
+	pongo2.SetAutoescape(true)
 
 	// Loop trough each Directory and register template files
 	walkFn := func(path string, info os.FileInfo, err error) error {

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -311,6 +311,21 @@ func Test_Invalid_Layout(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_XSS(t *testing.T) {
+	engine := New("./views", ".django")
+	require.NoError(t, engine.Load())
+
+	var buf bytes.Buffer
+	err := engine.Render(&buf, "index", map[string]interface{}{
+		"Title": "<script>alert('XSS')</script>",
+	}, "layouts/main")
+	require.NoError(t, err)
+
+	expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>&lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;</h1><h2>Footer</h2></body></html>`
+	result := trim(buf.String())
+	require.Equal(t, expect, result)
+}
+
 func Benchmark_Django(b *testing.B) {
 	expectSimple := `<h1>Hello, World!</h1>`
 	expectExtended := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, Admin!</h1><h2>Footer</h2></body></html>`

--- a/django/django_test.go
+++ b/django/django_test.go
@@ -326,6 +326,22 @@ func Test_XSS(t *testing.T) {
 	require.Equal(t, expect, result)
 }
 
+func Test_XSS_WithAutoEscapeDisabled(t *testing.T) {
+    engine := New("./views", ".django")
+    engine.SetAutoEscape(false)
+    require.NoError(t, engine.Load())
+
+    var buf bytes.Buffer
+    err := engine.Render(&buf, "index", map[string]interface{}{
+        "Title": "<script>alert('XSS')</script>",
+    }, "layouts/main")
+    require.NoError(t, err)
+
+    expect := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1><script>alert('XSS')</script></h1><h2>Footer</h2></body></html>`
+    result := trim(buf.String())
+    require.Equal(t, expect, result)
+}
+
 func Benchmark_Django(b *testing.B) {
 	expectSimple := `<h1>Hello, World!</h1>`
 	expectExtended := `<!DOCTYPE html><html><head><title>Main</title></head><body><h2>Header</h2><h1>Hello, Admin!</h1><h2>Footer</h2></body></html>`


### PR DESCRIPTION
The `pongo2` library by default has `autoescape` set to `True` as seen here: https://github.com/flosch/pongo2/blob/master/context.go#L11 . We should do the same as this exposes the user to XSS.

Fixes #281  