### PR TITLE
Update gofiber/template to v1.8.3

### DIFF
--- a/ace/go.mod
+++ b/ace/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require github.com/yosssi/ace v0.0.5
 
 require (
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/amber/go.mod
+++ b/amber/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/django/go.mod
+++ b/django/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/flosch/pongo2/v6 v6.0.0
 	github.com/gofiber/fiber/v2 v2.52.0
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/handlebars/go.mod
+++ b/handlebars/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.0
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/mailgun/raymond/v2 v2.0.48
 	github.com/stretchr/testify v1.8.4

--- a/html/go.mod
+++ b/html/go.mod
@@ -3,7 +3,7 @@ module github.com/gofiber/template/html/v2
 go 1.20
 
 require (
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/jet/go.mod
+++ b/jet/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/CloudyKit/jet/v6 v6.2.0
 	github.com/gofiber/fiber/v2 v2.52.0
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/mustache/go.mod
+++ b/mustache/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/cbroglie/mustache v1.4.0
 	github.com/gofiber/fiber/v2 v2.52.0
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 	github.com/valyala/bytebufferpool v1.0.0

--- a/pug/go.mod
+++ b/pug/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Joker/hpp v1.0.0
 	github.com/Joker/jade v1.1.3
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/slim/go.mod
+++ b/slim/go.mod
@@ -3,7 +3,7 @@ module github.com/gofiber/template/slim/v2
 go 1.20
 
 require (
-	github.com/gofiber/template v1.8.2
+	github.com/gofiber/template v1.8.3
 	github.com/gofiber/utils v1.1.0
 	github.com/mattn/go-slim v0.0.4
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Update gofiber/template to v1.8.3 for all the template engines.