### PR TITLE
Add Missing Parallel Benchmarks for Mustache Engine

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,10 +54,17 @@ jobs:
       - name: Save Benchmark Results
         uses: benchmark-action/github-action-benchmark@v1.19.3
         with:
-          tool: "go"
+          # What benchmark tool the output.txt came from
+          tool: 'go'
+          # Where the output from the benchmark tool is stored
           output-file-path: output.txt
+          # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          # Secret for Github
           github-token: ${{ secrets.BENCHMARK_TOKEN }}
+          # Directory that contains benchmark files on the GitHub pages branch
           benchmark-data-dir-path: "benchmarks"
+          # Workflow will fail when an alert happens
           fail-on-alert: true
           comment-on-alert: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           #summary-always: ${{ github.event_name != 'push' && github.event_name != 'workflow_dispatch' }}

--- a/ace/ace_test.go
+++ b/ace/ace_test.go
@@ -262,7 +262,7 @@ func Benchmark_Ace_Parallel(b *testing.B) {
 	})
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -276,7 +276,7 @@ func Benchmark_Ace_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended", func(bb *testing.B) {
+	b.Run("extended", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -290,7 +290,7 @@ func Benchmark_Ace_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -305,7 +305,7 @@ func Benchmark_Ace_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended_asserted", func(bb *testing.B) {
+	b.Run("extended_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {

--- a/amber/amber_test.go
+++ b/amber/amber_test.go
@@ -243,7 +243,7 @@ func Benchmark_Amber_Parallel(b *testing.B) {
 	})
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -257,7 +257,7 @@ func Benchmark_Amber_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended", func(bb *testing.B) {
+	b.Run("extended", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -271,7 +271,7 @@ func Benchmark_Amber_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -286,7 +286,7 @@ func Benchmark_Amber_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended_asserted", func(bb *testing.B) {
+	b.Run("extended_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {

--- a/handlebars/handlebars_test.go
+++ b/handlebars/handlebars_test.go
@@ -243,7 +243,7 @@ func Benchmark_Handlebars_Parallel(b *testing.B) {
 	// Note we don't register isAdmin again because handlebars does not support re-registering helpers
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -257,7 +257,7 @@ func Benchmark_Handlebars_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended", func(bb *testing.B) {
+	b.Run("extended", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -272,7 +272,7 @@ func Benchmark_Handlebars_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -287,7 +287,7 @@ func Benchmark_Handlebars_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended_asserted", func(bb *testing.B) {
+	b.Run("extended_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -335,7 +335,7 @@ func Benchmark_Html_Parallel(b *testing.B) {
 	})
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -349,7 +349,7 @@ func Benchmark_Html_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended", func(bb *testing.B) {
+	b.Run("extended", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -363,7 +363,7 @@ func Benchmark_Html_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -378,7 +378,7 @@ func Benchmark_Html_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended_asserted", func(bb *testing.B) {
+	b.Run("extended_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {

--- a/jet/jet_test.go
+++ b/jet/jet_test.go
@@ -235,7 +235,7 @@ func Benchmark_Jet_Parallel(b *testing.B) {
 	})
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -249,7 +249,7 @@ func Benchmark_Jet_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended", func(bb *testing.B) {
+	b.Run("extended", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -263,7 +263,7 @@ func Benchmark_Jet_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -278,7 +278,7 @@ func Benchmark_Jet_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended_asserted", func(bb *testing.B) {
+	b.Run("extended_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {

--- a/pug/pug_test.go
+++ b/pug/pug_test.go
@@ -256,7 +256,7 @@ func Benchmark_Pug_Parallel(b *testing.B) {
 	})
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -270,7 +270,7 @@ func Benchmark_Pug_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended", func(bb *testing.B) {
+	b.Run("extended", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -284,7 +284,7 @@ func Benchmark_Pug_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -299,7 +299,7 @@ func Benchmark_Pug_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_extended_asserted", func(bb *testing.B) {
+	b.Run("extended_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {

--- a/slim/slim_test.go
+++ b/slim/slim_test.go
@@ -219,7 +219,7 @@ func Benchmark_Slim_Parallel(b *testing.B) {
 	})
 	require.NoError(b, engine.Load())
 
-	b.Run("parallel_simple", func(bb *testing.B) {
+	b.Run("simple", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {
@@ -233,7 +233,7 @@ func Benchmark_Slim_Parallel(b *testing.B) {
 		})
 	})
 
-	b.Run("parallel_simple_asserted", func(bb *testing.B) {
+	b.Run("simple_asserted", func(bb *testing.B) {
 		bb.ReportAllocs()
 		bb.ResetTimer()
 		bb.RunParallel(func(pb *testing.PB) {


### PR DESCRIPTION
- Add missing parallel benchmarks for Mustache
- Fix the names of all the benchmarks. Before the change they had the word "parallel" twice in the name.
- Added missing key/value from Benchmark workflow based on official docs: https://github.com/benchmark-action/github-action-benchmark#minimal-setup Basically we were never storing results and comparing with previous run.