### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gofiber/maintainers


### PR DESCRIPTION
This will allow github to auto assign the gofiber/maintainers team as reviewers of each new Pull Request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented a CODEOWNERS file to specify ownership of the project files by `@gofiber/maintainers`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->