### PR TITLE
fix: fixed the example of django using NewPathForwardingFileSystem no…

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -116,7 +116,7 @@ var viewsAsssets embed.FS
 
 func main() {
 	// Create a new engine
-	engine := NewPathForwardingFileSystem(http.FS(viewsAsssets), "/views", ".django")
+	engine := django.NewPathForwardingFileSystem(http.FS(viewsAsssets), "/views", ".django")
 
 	// Pass the engine to the Views
 	app := fiber.New(fiber.Config{


### PR DESCRIPTION
fixed the example of django using NewPathForwardingFileSystem not using the package name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the function reference in the README to reflect the correct usage within the `django` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->