### PR TITLE
Fix Slim template example 

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -37,7 +37,7 @@ html
     title Main
     include ../partials/meta.slim
   body
-    | {{embed}}
+    == embed
 ```
 
 ```go


### PR DESCRIPTION
Changing `| {{embed}}` to `== embed`, because `| {{embed}}` not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for embedding content in HTML files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->