### PR TITLE
docs: Update HTML template example

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -72,7 +72,7 @@ func main() {
 
 	// Or from an embedded system
 	// See github.com/gofiber/embed for examples
-	// engine := html.NewFileSystem(http.Dir("./views", ".html"))
+	// engine := html.NewFileSystem(http.Dir("./views"), ".html")
 
 	// Pass the engine to the Views
 	app := fiber.New(fiber.Config{


### PR DESCRIPTION
I believe http.Dir only takes 1 parameter - https://pkg.go.dev/net/http#Dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the parameter passing example in `html/README.md` for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->