### PR TITLE
Update dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,22 @@ updates:
           - "🤖 Dependencies"
       schedule:
           interval: "daily"
+      groups:
+          gofiber:
+              patterns:
+                  - "github.com/gofiber/*"
+          valyala:
+              patterns:
+                  - "github.com/valyala/*"
+          test-libs:
+              patterns:
+                  - "github.com/stretchr/*"
+                  - "github.com/davecgh/*"
+                  - "github.com/pmezard/*"
+                  - "github.com/google/uuid*"
+                  - "github.com/andybalholm/*"
+                  - "github.com/klauspost/*"
+                  - "github.com/mattn/*"
+                  - "github.com/rivo/*"
+                  - "gopkg.in/yaml.*"
+                  - "golang.org/x/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,31 +30,9 @@ updates:
                   - "github.com/stretchr/*"
                   - "github.com/davecgh/*"
                   - "github.com/pmezard/*"
-          compression:
-              patterns:
-                  - "github.com/andybalholm/*"
-                  - "github.com/klauspost/*"
-          mattn:
-              patterns:
-                  - "github.com/mattn/*"
-          uuid:
-              patterns:
-                  - "github.com/google/uuid*"
-          unicode:
-              patterns:
-                  - "github.com/rivo/*"
           yaml:
               patterns:
                   - "gopkg.in/yaml.*"
           golang-x:
               patterns:
                   - "golang.org/x/*"
-          template-engines:
-              patterns:
-                  - "github.com/CloudyKit/*"
-                  - "github.com/Joker/*"
-                  - "github.com/cbroglie/*"
-                  - "github.com/eknkc/*"
-                  - "github.com/flosch/*"
-                  - "github.com/mailgun/*"
-                  - "github.com/yosssi/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,10 +30,31 @@ updates:
                   - "github.com/stretchr/*"
                   - "github.com/davecgh/*"
                   - "github.com/pmezard/*"
-                  - "github.com/google/uuid*"
+          compression:
+              patterns:
                   - "github.com/andybalholm/*"
                   - "github.com/klauspost/*"
+          mattn:
+              patterns:
                   - "github.com/mattn/*"
+          uuid:
+              patterns:
+                  - "github.com/google/uuid*"
+          unicode:
+              patterns:
                   - "github.com/rivo/*"
+          yaml:
+              patterns:
                   - "gopkg.in/yaml.*"
+          golang-x:
+              patterns:
                   - "golang.org/x/*"
+          template-engines:
+              patterns:
+                  - "github.com/CloudyKit/*"
+                  - "github.com/Joker/*"
+                  - "github.com/cbroglie/*"
+                  - "github.com/eknkc/*"
+                  - "github.com/flosch/*"
+                  - "github.com/mailgun/*"
+                  - "github.com/yosssi/*"


### PR DESCRIPTION
## Summary
- remove GitHub Actions dependency group
- drop obsolete template-engine group in Dependabot config

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: unsupported version of the configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686cf3fa282483269aa14f972b0ad264